### PR TITLE
Feature update: startJob button updated, blender download, loop all task, download project file, upload image to GCS

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -19,10 +19,21 @@ export default function App() {
   }
 
   useEffect(()=>{
-    window.api.invoke('auth:is-token-expired')
-      .then((flag: boolean) => {
-        setAccessHome(flag);
+    const validateToken = () => {
+      window.api.invoke('auth:is-token-expired')
+        .then((flag: boolean) => {
+          setAccessHome(flag);
       })
+    };
+
+    // run on mount
+    validateToken();
+
+    window.api.receive("worker:start-render", validateToken);
+
+    return () => {
+      window.api.removeAllListeners("worker:start-render");
+    }
   },[])
 
   if (accessHome === false) {

--- a/app/components/homepage/Home.tsx
+++ b/app/components/homepage/Home.tsx
@@ -6,14 +6,24 @@ import React from "react"
 
 const Home = () => {
   const [allowedCpuThreads, setAllowedCpuThreads] = React.useState([6]);
+  const [jobRunning, setJobRunning] = React.useState(false);
 
   const handleSliderChange = (value: number[]) => {
     setAllowedCpuThreads(value)
+    
+
   }
 
   const handleStartButtonPress = () => {
     console.warn("hiiii")
     window.api.send('home:start-job', allowedCpuThreads); // when start button pressed send cpu thread count user wants to use for rendering
+    setJobRunning(true)
+  }
+
+  const handleStopButtonPress = () => {
+    console.warn("hiiii")
+    window.api.send('home:stop-job'); // when start button pressed send cpu thread count user wants to use for rendering
+    setJobRunning(false)
   }
 
   return (
@@ -35,10 +45,16 @@ const Home = () => {
 
       {/* Buttons */}
       <div className="buttons flex gap-4">
-        <Button variant="default" size="lg" className="start-job-button" onClick={handleStartButtonPress}>
+        <Button 
+          variant={jobRunning ? "ghost" : "default"} 
+          size="lg" 
+          className="start-job-button" 
+          onClick={handleStartButtonPress}
+          disabled={jobRunning}
+        >
           Start Job
         </Button>
-        <Button variant="destructive" size="lg" className="stop-job-button">
+        <Button variant="destructive" size="lg" className="stop-job-button" onClick={handleStopButtonPress}>
           Stop Job
         </Button>
       </div>

--- a/lib/main/main.ts
+++ b/lib/main/main.ts
@@ -6,6 +6,7 @@ import { HttpResponseStatus, UserInfo } from '../utils'
 import { login } from '../login/loginManager'
 
 import keytar from 'keytar'
+import { loop, stopWhenCurrentJobIsFinished } from '../worker/main'
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
@@ -44,12 +45,19 @@ app.on('window-all-closed', () => {
 // In this file, you can include the rest of your app's specific main process
 // code. You can also put them in separate files and import them here.
 
-ipcMain.on('home:start-job', (_event, args) => {
-  console.warn("Hi from renderer, [home] got message", args);
+ipcMain.on('home:start-job', (_event, allowedCpuThreads) => {
+  console.warn("Hi from renderer, [home] got message", allowedCpuThreads);
   // runBlenderForRenderingImages((_event, msg) => {console.warn(msg)})
   // .then(() => {console.warn("finished rendering")})
 
-  fetchJob().then(() => console.warn('login post request done.')) // we are golden
+  loop(allowedCpuThreads);
+
+  //fetchJob().then(() => console.warn('login post request done.')) // we are golden
+})
+
+ipcMain.on('home:stop-job', (_event) => {
+  console.warn("[main] Stop job!");
+  stopWhenCurrentJobIsFinished();
 })
 
 ipcMain.handle('login:request', async (_event, userInfo: UserInfo) => {

--- a/lib/main/main.ts
+++ b/lib/main/main.ts
@@ -75,7 +75,7 @@ ipcMain.handle('login:request', async (_event, userInfo: UserInfo) => {
 
 ipcMain.handle('auth:is-token-expired', async (_event) => {
   const tokenExpireDate = await keytar.getPassword("org.blendit", "auth-token-expires-in");
-  console.warn("keytar: ", tokenExpireDate);
+  if(tokenExpireDate!=null){console.warn("keytar: ",tokenExpireDate," ", parseInt(tokenExpireDate)- (Date.now()));}
   // return false;
   if (tokenExpireDate != null && parseInt(tokenExpireDate) > Date.now()) {
     return true;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -45,3 +45,6 @@ export type JobApiResponse = {
 // 				"projectId", projectId,
 // 				"userId", userId,
 // 				"frame", frame));
+
+export const blenderWinDownloadUrl = 'https://mirror.clarkson.edu/blender/release/Blender4.5/blender-4.5.0-windows-x64.zip'
+export const blenderLinuxDownloadUrl = 'https://mirror.clarkson.edu/blender/release/Blender4.5/blender-4.5.0-linux-x64.tar.xz'

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -8,7 +8,7 @@ export function cn(...inputs: ClassValue[]) {
 
 export type Job = {
   id: string;
-  outputPattern: string;
+  outputPattern?: string;
   blendFileLocalPath: string;
   frame: number;
 }
@@ -37,7 +37,18 @@ export type JobApiResponse = {
   projectId: number;
   userId: string;
   frame: number;
+  fileName: string;
 }
+
+export type JobFileMetadata = {
+  workerId?: string;
+  userId: string;
+  projectId: number;
+  fileName: string;
+  frame: number;
+  jobId: number;
+}
+
 // }
 // "status", "successs",
 // 				"url", url,

--- a/lib/worker/blender.ts
+++ b/lib/worker/blender.ts
@@ -1,7 +1,12 @@
-import { spawn } from "child_process";
+import { execFile, spawn } from "child_process";
 import path from "path";
-import { Job, Settings } from "../utils";
-import fs from "node:fs/promises"
+import { blenderLinuxDownloadUrl, blenderWinDownloadUrl, Job, Settings } from "../utils";
+import fs from "fs"
+import { app } from "electron";
+import { promisify } from "util";
+import axios from "axios";
+import extract from "extract-zip";
+import * as tar from "tar";
 
 export async function runBlenderForRenderingImages(
     job: Job,
@@ -9,11 +14,12 @@ export async function runBlenderForRenderingImages(
     onProgress: (p: any) => void) {
     
     // Output directory of rendered image
-    const outDir = path.join(process.cwd(), '.renders', `job_${job.id}`);
-    await fs.mkdir(outDir, { recursive: true });
+    const userData = app.getPath('userData');
+    const outDir = ensureOutputDir(path.join(userData, 'projectFiles', "renderedImages"));
 
     // Where is blender binary?
-    const blenderExe = settings.blenderPath || 'blender';
+    // const blenderDir = path.join(userData, "blender");
+    const blenderExe = await resolveBlenderExe();
 
     // number of threads allowed by user
     const threadsArg = settings.cpuThreads ? ['--threads', String(settings.cpuThreads)] : [];
@@ -62,4 +68,111 @@ export async function runBlenderForRenderingImages(
             }
         });
     })
+}
+
+function ensureOutputDir(dirPath: string): string {
+
+  try {
+    if (!fs.existsSync(dirPath)) {
+      fs.mkdirSync(dirPath, { recursive: true });
+    }
+  } catch (err) {
+    console.error("Failed to create projectFiles directory:", err);
+    throw err;
+  }
+  return dirPath;
+}
+
+async function resolveBlenderExe() {
+    const execFileAsync = promisify(execFile);
+
+    const userData = app.getPath('userData');
+    const blenderDir = path.join(userData, "blendit", "blender");
+    const blenderExe = path.join(
+        blenderDir,
+        process.platform === "win32" 
+            ? "blender-4.5.0-windows-x64"
+            : process.platform === "linux"
+                ? "blender-4.5.0-linux-x64" : "blender"
+        , process.platform === "win32" 
+            ? "blender.exe"
+            : process.platform === "linux"
+                ? "blender" : "Blender"
+    );
+
+    // check if $userData/blendit/blender/blender.exe exists
+    if (fs.existsSync(blenderExe)) {
+        try {
+            await execFileAsync(blenderExe, ["--version"]);
+            console.warn("Blender is already installed and working");
+            return blenderExe;
+        } catch (error) {
+            console.warn(error + " Blender binary exists but failed to run, redownloading");
+        }
+    }
+
+    // else download and extract
+    console.warn("Downloading blender");
+    await downloadBlenderArchive(blenderDir);
+    
+    // check if executable runs
+    await execFileAsync(blenderExe, ["--version"]);
+    console.warn("Blender installed at:", blenderExe);
+
+    return blenderExe;
+
+}
+
+async function downloadFile(url: string, dest: string) {
+  const writer = fs.createWriteStream(dest);
+  const response = await axios.get(url, { responseType: "stream" });
+
+    return new Promise<void>((resolve, reject) => {
+        response.data.pipe(writer);
+        let error: Error | null = null;
+        writer.on("error", err => {
+            error = err;
+            writer.close();
+            reject(err);
+        });
+        writer.on("close", () => {
+            if (!error) resolve();
+        });
+    });
+}
+
+async function downloadBlenderArchive(destPath: string) {
+    let url: string;
+    let archiveName: string;
+
+    if (process.platform === "win32") {
+        url = blenderWinDownloadUrl;
+        archiveName = "blender.zip";
+    }else if (process.platform === "linux") {
+        url = blenderLinuxDownloadUrl;
+        archiveName = "blender.tar.xz";
+    } else {
+        url = blenderLinuxDownloadUrl;
+        archiveName = "blender.zip";
+    }
+    const archivePath = path.join(destPath, archiveName);
+
+    // ensure $userData/blendit exists
+    if (!fs.existsSync(archivePath)) {
+        fs.mkdirSync(archivePath, {recursive: true});
+    }
+
+    console.warn("Downloading blender from " + url + " into " + archivePath);
+    await downloadFile(url, archivePath); // $userData/blendit/blender.zip
+
+    console.warn("Extracting Blender...");
+    if (archiveName.endsWith('.zip')) {
+        await extract(archivePath, { dir: destPath }); // extract to $/userData/blendit
+    } else {
+        await tar.x({file: archivePath, cwd: destPath});
+    }
+
+    // delete archive
+    fs.unlinkSync(archivePath);
+    console.warn("blender extracted to ", destPath);
 }

--- a/lib/worker/blender.ts
+++ b/lib/worker/blender.ts
@@ -15,7 +15,7 @@ export async function runBlenderForRenderingImages(
     
     // Output directory of rendered image
     const userData = app.getPath('userData');
-    const outDir = ensureOutputDir(path.join(userData, 'projectFiles', "renderedImages"));
+    const outDir = ensureOutputDir(path.join(userData, 'blendit', "renderedImages"));
 
     // Where is blender binary?
     // const blenderDir = path.join(userData, "blender");
@@ -124,21 +124,37 @@ async function resolveBlenderExe() {
 }
 
 async function downloadFile(url: string, dest: string) {
-  const writer = fs.createWriteStream(dest);
-  const response = await axios.get(url, { responseType: "stream" });
-
-    return new Promise<void>((resolve, reject) => {
+    try {
+        
+        const response = await axios.get(
+            url, 
+            { 
+                responseType: "stream",
+                onDownloadProgress: (progressEvent) => {
+                    if (progressEvent.total != null) {
+                        const percentCompleted = Math.round((progressEvent.loaded * 100) / progressEvent.total);
+                        console.warn("blender Download progress: ", percentCompleted);
+                    }
+                }
+            }
+        );
+        const writer = fs.createWriteStream(dest);
         response.data.pipe(writer);
-        let error: Error | null = null;
-        writer.on("error", err => {
-            error = err;
-            writer.close();
-            reject(err);
+        return new Promise<void>((resolve, reject) => {
+            
+            let error: Error | null = null;
+            writer.on("error", err => {
+                error = err;
+                writer.close();
+                reject(err);
+            });
+            writer.on("close", () => {
+                if (!error) resolve();
+            });
         });
-        writer.on("close", () => {
-            if (!error) resolve();
-        });
-    });
+    } catch (error) {
+        console.warn("there is an error downloading blender");
+    }
 }
 
 async function downloadBlenderArchive(destPath: string) {
@@ -147,7 +163,7 @@ async function downloadBlenderArchive(destPath: string) {
 
     if (process.platform === "win32") {
         url = blenderWinDownloadUrl;
-        archiveName = "blender.zip";
+        archiveName = "blender-4.5.0-windows-x64.zip";
     }else if (process.platform === "linux") {
         url = blenderLinuxDownloadUrl;
         archiveName = "blender.tar.xz";
@@ -155,15 +171,17 @@ async function downloadBlenderArchive(destPath: string) {
         url = blenderLinuxDownloadUrl;
         archiveName = "blender.zip";
     }
-    const archivePath = path.join(destPath, archiveName);
+    let archivePath = destPath;
 
     // ensure $userData/blendit exists
     if (!fs.existsSync(archivePath)) {
         fs.mkdirSync(archivePath, {recursive: true});
     }
 
+    archivePath = path.join(destPath, archiveName);
+
     console.warn("Downloading blender from " + url + " into " + archivePath);
-    await downloadFile(url, archivePath); // $userData/blendit/blender.zip
+    await downloadFile(url, archivePath); // $userData/blendit/
 
     console.warn("Extracting Blender...");
     if (archiveName.endsWith('.zip')) {

--- a/lib/worker/imageUploader.ts
+++ b/lib/worker/imageUploader.ts
@@ -1,0 +1,46 @@
+import axios from "axios";
+import keytar from 'keytar';
+import fs from "fs";
+import { JobFileMetadata } from "../utils";
+
+export async function uploadImageToServer(
+    imgPath: string,
+    jobFileMetadata: JobFileMetadata) {
+    const token = await keytar.getPassword("org.blendit", "auth-token");
+    try {
+        const response = await axios({
+            method: 'post',
+            baseURL: 'http://localhost:4001',
+            url: '/api/worker/job-success',
+
+            headers: {
+                Authorization: `Bearer ${token}`
+            },
+
+            data: jobFileMetadata,
+        });
+
+        const presignedUploadUrl = response.data.url;
+        console.warn("image upload url: ", presignedUploadUrl);
+
+        const fileStream = fs.createReadStream(imgPath);
+
+        if (presignedUploadUrl) {
+            const response = await axios({
+                method: 'put',
+                url: presignedUploadUrl,
+                headers: {
+                    'Content-Type': 'application/octet-stream',
+                },
+                data: fileStream,
+                maxBodyLength: Infinity,
+                maxContentLength: Infinity
+            });
+            console.warn("Upload Success: ", response);
+        }
+    } catch (error) {
+        console.error("Can not get upload image url: ", error);
+        throw error;
+    }
+
+}

--- a/lib/worker/jobManager.ts
+++ b/lib/worker/jobManager.ts
@@ -6,9 +6,10 @@ import path from "path";
 import fs from "fs";
 
 export async function fetchJob() {
+    console.warn("fetch job called...");
 
     const token = await keytar.getPassword("org.blendit", "auth-token");
-    console.warn(token);
+    console.warn("[fetchJob] token:", token);
     // TODO: Fetch job from fileserver
     try {
         const response = await axios(
@@ -22,13 +23,13 @@ export async function fetchJob() {
                 }
             }
         )
-        console.warn(response.data);
+        console.warn("Response data from job-request api: ", response.data);
         const job : JobApiResponse = response.data;
         //console.warn(job.url + " " + job.frame + " " + job.jobId + " " +  job.projectId + " " + job.status + " " + job.userId)
 
         // download project from Google Cloud Storage and store in userData
         if (job.status == "success") {
-            const userDataPath = ensureProjectFilesDir(); // $/userData/blendit/projectFiles/blender_project.blend
+            const userDataPath = ensureProjectFilesDir(job.fileName); // $/userData/blendit/projectFiles/blender_project.blend
             const downloadSuccessful = await downloadFileFromGCS(job.url, userDataPath);
             console.warn("download successful " + downloadSuccessful);
             console.warn("path to file: " + userDataPath);
@@ -37,7 +38,8 @@ export async function fetchJob() {
         return null;
         
     } catch (error) {
-        console.error(error);
+        console.warn("hi there is an error at fetch Job");
+        //console.error(error);
         throw error;
     }
 }
@@ -46,7 +48,7 @@ export async function fetchJob() {
  * Ensures the projectFiles directory exists inside app.getPath("userData").
  * Returns the full path to the directory.
  */
-function ensureProjectFilesDir(): string {
+function ensureProjectFilesDir(fileName: string): string {
   const dirPath = path.join(app.getPath("userData"), "blendit", "projectFiles");
 
   try {
@@ -57,15 +59,19 @@ function ensureProjectFilesDir(): string {
     console.error("Failed to create projectFiles directory:", err);
     throw err;
   }
-  return path.join(dirPath, "blender_project.blend");
+  return path.join(dirPath, fileName);
 }
 
 async function downloadFileFromGCS(presignedUrl: string, localFilePath: string) {
     try {
         const response = await axios({
-            method: 'GET',
+            method: 'get',
             url: presignedUrl,
             responseType: 'stream',
+            onDownloadProgress: (progressEvent) => {
+                const percentCompleted = Math.round(progressEvent.loaded * 100 / (progressEvent.total ? progressEvent.total : 1));
+                console.warn("Project Download progress: ", percentCompleted);
+            }
         });
 
         const writer = fs.createWriteStream(localFilePath);

--- a/lib/worker/jobManager.ts
+++ b/lib/worker/jobManager.ts
@@ -28,7 +28,7 @@ export async function fetchJob() {
 
         // download project from Google Cloud Storage and store in userData
         if (job.status == "success") {
-            const userDataPath = ensureProjectFilesDir(); // $/userData/projectFiles/blender_project.blend
+            const userDataPath = ensureProjectFilesDir(); // $/userData/blendit/projectFiles/blender_project.blend
             const downloadSuccessful = await downloadFileFromGCS(job.url, userDataPath);
             console.warn("download successful " + downloadSuccessful);
             console.warn("path to file: " + userDataPath);
@@ -47,7 +47,7 @@ export async function fetchJob() {
  * Returns the full path to the directory.
  */
 function ensureProjectFilesDir(): string {
-  const dirPath = path.join(app.getPath("userData"), "projectFiles");
+  const dirPath = path.join(app.getPath("userData"), "blendit", "projectFiles");
 
   try {
     if (!fs.existsSync(dirPath)) {

--- a/lib/worker/main.ts
+++ b/lib/worker/main.ts
@@ -1,47 +1,120 @@
 import path from "path";
-import { JobApiResponse } from "../utils";
+import { Job, JobApiResponse, JobFileMetadata, Settings } from "../utils";
 import { fetchJob } from "./jobManager";
 import { app } from "electron";
+import { runBlenderForRenderingImages } from "./blender";
+import fs from "fs";
+import { uploadImageToServer } from "./imageUploader";
+
+let stopJobFlag = false;
+
+export function stopWhenCurrentJobIsFinished() {
+    stopJobFlag = true;
+    console.warn("Stopping rendering after current job is finished...")
+}
+
+export async function loop(allowedCpuThreads: number) {
+    stopJobFlag = false;
+    while (!stopJobFlag) {
+        console.warn("hello loop");
+        try {
+            /** If stop job is called this loop closes with a warning
+            * ?: Do you want to stop after this project is finished rendering
+            * [Stop immediately] [Stop after current rendering is complete]
+            * 
+            */
 
 
-export async function loop() {
-    while (true) {
-        /** If stop job is called this loop closes with a warning
-         * ?: Do you want to stop after this project is finished rendering
-         * [Stop immediately] [Stop after current rendering is complete]
-         * 
-         */
+            /**
+             * fetch job from workerHandler server
+             * show progress and size of downloading file
+             */
+
+            const jobApiResponse : JobApiResponse | null = await fetchJob();
+            console.warn("[loop] job api response: ", jobApiResponse);
+
+            if (jobApiResponse == null) {
+                // wait 1 minute before sending another request to server to avoid overloading
+                console.warn("waiting 1 minute");
+                await new Promise(resolve => setTimeout(resolve, 60_000));
+                continue;
+            }
 
 
-        /**
-         * fetch job from workerHandler server
-         * show progress and size of downloading file
-         */
+            /**
+             * render the project
+             */
 
-        const jobApiResponse : JobApiResponse | null = await fetchJob();
+            const pathToProject = path.join(app.getPath('userData'), 'blendit', "projectFiles", jobApiResponse.fileName);
+            const job: Job = {
+                id: String (jobApiResponse.jobId),
+                outputPattern: 'frame_#####',
+                blendFileLocalPath: pathToProject,
+                frame: jobApiResponse.frame,
+            }
+            const settings: Settings = {
+                cpuThreads: allowedCpuThreads
+            }
+            console.warn("[loop] job: ", job);
+            console.warn("[loop] settings: ", settings);
+            await runBlenderForRenderingImages(job, settings, (msg) => {console.warn(msg)});
+            
 
-        if (jobApiResponse == null) {
-            // wait 1 minute before sending another request to server to avoid overloading
+            /**
+             * report render finished to workerHandler
+             * and upload the rendered image to GCS
+             */
+            const frameName = "frame_" + String(jobApiResponse.frame).padStart(5, '0') + ".png";
+            const imgPath = path.join(app.getPath('userData'), 'blendit', "renderedImages", frameName);
+            const jobFileMetadata: JobFileMetadata = {
+                userId: jobApiResponse.userId,
+                projectId: jobApiResponse.projectId,
+                fileName: frameName,
+                frame: jobApiResponse.frame,
+                jobId: jobApiResponse.jobId
+            }
+            console.warn("[loop] frameName: ", jobApiResponse);
+            console.warn("[loop] image path: ", imgPath);
+            console.warn("[loop] job file metadata: ", jobFileMetadata);
+
+            await uploadImageToServer(imgPath, jobFileMetadata);
+
+            // remove completed project and frame
+            removeAllArchives(jobApiResponse.fileName, frameName);
+
+
+        } catch (error) {
+            //console.error(error);
+            /**
+             * If any of these processes fail, retry with a 1 minute break,
+             * to avoid server load
+             */
+            console.warn("waiting 1 minute");
             await new Promise(resolve => setTimeout(resolve, 60_000));
             continue;
         }
 
 
-        /**
-         * render the project
-         */
 
-        const pathToProject = path.join(app.getPath('userData'), "projectFiles", "blender_project.blend");
         
-
-        /**
-         * report render finished to workerHandler
-         * and upload the rendered image to GCS
-         */
-
-        /**
-         * If any of these processes fail, retry with a 1 minute break,
-         * to avoid server load
-         */
+        await new Promise(resolve => setTimeout(resolve, 5_000));
     }
+    console.warn("Job stopped!!!!");
+}
+
+function removeAllArchives(projectName: string, frameName: string) {
+    fs.unlink(
+        path.join(app.getPath('userData'), 'blendit', 'projectFiles', projectName), 
+        (err) => {
+            if (err) throw err;
+            console.warn('blender_project.blend was deleted');
+        }
+    );
+    fs.unlink(
+        path.join(app.getPath('userData'), 'blendit', 'renderedImages', frameName), 
+        (err) => {
+            if (err) throw err;
+            console.warn(frameName, ' was deleted');
+        }
+    );
 }

--- a/lib/worker/main.ts
+++ b/lib/worker/main.ts
@@ -1,29 +1,47 @@
+import path from "path";
+import { JobApiResponse } from "../utils";
+import { fetchJob } from "./jobManager";
+import { app } from "electron";
 
 
 export async function loop() {
-    /** If stop job is called this loop closes with a warning
-     * ?: Do you want to stop after this project is finished rendering
-     * [Stop immediately] [Stop after current rendering is complete]
-     * 
-     */
+    while (true) {
+        /** If stop job is called this loop closes with a warning
+         * ?: Do you want to stop after this project is finished rendering
+         * [Stop immediately] [Stop after current rendering is complete]
+         * 
+         */
 
 
-    /**
-     * fetch job from workerHandler server
-     * show progress and size of downloading file
-     */
+        /**
+         * fetch job from workerHandler server
+         * show progress and size of downloading file
+         */
 
-    /**
-     * render the project
-     */
+        const jobApiResponse : JobApiResponse | null = await fetchJob();
 
-    /**
-     * report render finished to workerHandler
-     * and upload the rendered image to GCS
-     */
+        if (jobApiResponse == null) {
+            // wait 1 minute before sending another request to server to avoid overloading
+            await new Promise(resolve => setTimeout(resolve, 60_000));
+            continue;
+        }
 
-    /**
-     * If any of these processes fail, retry with a 1 minute break,
-     * to avoid server load
-     */
+
+        /**
+         * render the project
+         */
+
+        const pathToProject = path.join(app.getPath('userData'), "projectFiles", "blender_project.blend");
+        
+
+        /**
+         * report render finished to workerHandler
+         * and upload the rendered image to GCS
+         */
+
+        /**
+         * If any of these processes fail, retry with a 1 minute break,
+         * to avoid server load
+         */
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-router": "^7.8.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.0",
+        "tar": "^7.4.3",
         "tw-animate-css": "^1.3.2",
         "zod": "^4.1.5"
       },
@@ -1869,7 +1870,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.4"
@@ -1882,7 +1882,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -10874,7 +10873,6 @@
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
       "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -10926,7 +10924,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -10936,7 +10933,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -10946,7 +10942,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
       "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
@@ -10959,7 +10954,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
       "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
@@ -10975,7 +10969,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-router": "^7.8.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.0",
+    "tar": "^7.4.3",
     "tw-animate-css": "^1.3.2",
     "zod": "^4.1.5"
   },


### PR DESCRIPTION
1. The StartJob button is now disabled once pressed. This means there will be no risk of starting 2 or more task loops
2. Blender is auto-downloaded if not available in the `$userData/blendit/` directory. This is a portable version of blender
3. The task loop is added, which does the following tasks repeatedly (with a 1-minute pause after each run):
    a. fetch a job from the workerHandler microservice. If no job is available, wait 1 minute, then try again.
    b. render the job
    c. upload the rendered image
    d. delete project `.blend` file and rendered image `.png` file
4. download project from GCS (using pre-signed url)
5. upload finished render to GCS (using pre-signed url)